### PR TITLE
fix | sprint1 | FRB-23 | Pem키 관리 방식 변경 + Mqtt 연결 객체 수정 + .env파일로 IAM 키 관리 | 김우영

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ out/
 ### MQTT(shadow) 인증서 보안 경로 제외
 src/main/resources/certs/
 
+### 환경변수 파일
+.env
+
 # 예시: .gitignore
 *.lck
 
@@ -94,12 +97,6 @@ cmake-build-*/
 
 # Mongo Explorer plugin
 .idea/**/mongoSettings.xml
-
-# File-based project format
-*.iws
-
-# IntelliJ
-out/
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,12 @@ dependencies {
 
 	// swagger doc
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+	// AWS SDK for IoT Data Plane
+	implementation platform('software.amazon.awssdk:bom:2.25.19')
+	implementation 'software.amazon.awssdk:secretsmanager'
+	implementation 'software.amazon.awssdk:regions'
+	implementation 'software.amazon.awssdk:iotdataplane'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/factoreal/backend/Config/AwsMqttListener.java
+++ b/src/main/java/com/factoreal/backend/Config/AwsMqttListener.java
@@ -1,16 +1,16 @@
 package com.factoreal.backend.Config;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.factoreal.backend.Dto.SensorDto;
 import com.factoreal.backend.Service.SensorService;
 import com.factoreal.backend.Util.SslUtil;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.paho.client.mqttv3.*;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.stereotype.Component;
 
 import javax.net.ssl.SSLSocketFactory;
 import java.nio.charset.StandardCharsets;
@@ -20,12 +20,12 @@ import java.nio.charset.StandardCharsets;
  * - 사물(센서)의 shadow update 메시지를 구독
  */
 @Slf4j
-@Component
+//@Component // 빈에 등록되지 않도록 변경
 @RequiredArgsConstructor
 public class AwsMqttListener {
 
     private final SensorService sensorService;
-
+    private final SslUtil sslUtil;
     @PostConstruct
     public void connect() throws Exception {
 
@@ -45,11 +45,18 @@ public class AwsMqttListener {
 
 
         // 🔐 SSL 인증서 경로 설정
-        SSLSocketFactory sslFactory = SslUtil.getSocketFactory(
-                "src/main/resources/certs/root.pem",
-                "src/main/resources/certs/54e5d2549e672108375364398317635c85a2a4082c90ff9378d02a118bd41800-certificate.pem.crt",
-                "src/main/resources/certs/54e5d2549e672108375364398317635c85a2a4082c90ff9378d02a118bd41800-private.pem.key"
-        );
+        SSLSocketFactory sslFactory;
+        try {
+            // AWS Secret Manager에 정의된 secret 식별자 사용
+            sslFactory = sslUtil.getSocketFactoryFromSecrets("Secret Manger 식별자");
+        }catch (Exception e){
+            // AWS Secret Manager에 Pem이 등록되지 않았다면 그대로 로컬의 pem키 사용.
+            sslFactory = sslUtil.getSocketFactoryFromFiles(
+                    "src/main/resources/certs/root.pem",
+                    "src/main/resources/certs/54e5d2549e672108375364398317635c85a2a4082c90ff9378d02a118bd41800-certificate.pem.crt",
+                    "src/main/resources/certs/54e5d2549e672108375364398317635c85a2a4082c90ff9378d02a118bd41800-private.pem.key"
+            );
+        }
         MqttConnectOptions options = new MqttConnectOptions();
         options.setSocketFactory(sslFactory);
 

--- a/src/main/java/com/factoreal/backend/Config/AwsServiceConfig.java
+++ b/src/main/java/com/factoreal/backend/Config/AwsServiceConfig.java
@@ -1,0 +1,43 @@
+package com.factoreal.backend.Config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.iotdataplane.IotDataPlaneClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+
+@Configuration
+public class AwsServiceConfig {
+
+    @Value("${aws.access-key}")
+    private String accessKey;
+
+    @Value("${aws.secret-key}")
+    private String secretKey;
+
+    @Value("${aws.region}")
+    private String region;
+
+    @Bean
+    public AwsBasicCredentials awsCredentials() {
+        return AwsBasicCredentials.create(accessKey, secretKey);
+    }
+
+    @Bean
+    public SecretsManagerClient awsSecretsManagerClient() {
+        return  SecretsManagerClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(this::awsCredentials)
+                .build();
+    }
+
+    @Bean
+    public IotDataPlaneClient iotDataPlaneClient() {
+        return IotDataPlaneClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(this::awsCredentials)
+                .build();
+    }
+}

--- a/src/main/java/com/factoreal/backend/Config/MqttConfig.java
+++ b/src/main/java/com/factoreal/backend/Config/MqttConfig.java
@@ -1,0 +1,45 @@
+package com.factoreal.backend.Config;
+
+import com.factoreal.backend.Util.SslUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.net.ssl.SSLSocketFactory;
+
+@Slf4j
+@Configuration
+public class MqttConfig {
+    @Bean
+    public MqttClient mqttClient(SslUtil sslUtil) throws Exception {
+        // 🟢 AWS IoT 브로커 주소 및 포트 설정
+        String broker = "ssl://a2q1cmw33m6k7u-ats.iot.ap-northeast-2.amazonaws.com:8883";
+        // 🟢 고유한 MQTT 클라이언트 ID 생성
+        String clientId = "SPRING_Dain";
+        // 🔐 SSL 인증서 경로 설정
+        SSLSocketFactory sslFactory;
+        try {
+            // AWS Secret Manager에 정의된 secret 식별자 사용
+            sslFactory = sslUtil.getSocketFactoryFromSecrets("monitory/dev/iotSecrets");
+            log.info("✅Secret Manager에서 Pem키 가져오기 성공!");
+        }catch (Exception e){
+            // AWS Secret Manager에 Pem이 등록되지 않았다면 그대로 로컬의 pem키 사용.
+            log.info("❌Secret Manager에서 Pem키 가져오기 실패 {}", e.getMessage());
+            sslFactory = sslUtil.getSocketFactoryFromFiles(
+                    "src/main/resources/certs/root.pem",
+                    "src/main/resources/certs/e26518c769f6e58cdf25f97a56b948cc340e1e8f5ff053f7188db2bbc4a3b4bf-certificate.pem.crt",
+                    "src/main/resources/certs/e26518c769f6e58cdf25f97a56b948cc340e1e8f5ff053f7188db2bbc4a3b4bf-private.pem.key"
+            );
+            log.info("✅로컬 경로에서 Pem키 가져오기 성공!");
+        }
+        MqttConnectOptions options = new MqttConnectOptions();
+        options.setSocketFactory(sslFactory);
+
+        MqttClient client = new MqttClient(broker, clientId);
+        client.connect(options);
+        log.info("✅Mqtt 연결 성공!");
+        return client;
+    }
+}

--- a/src/main/java/com/factoreal/backend/Service/MqttService.java
+++ b/src/main/java/com/factoreal/backend/Service/MqttService.java
@@ -1,0 +1,55 @@
+package com.factoreal.backend.Service;
+
+import com.factoreal.backend.Dto.SensorDto;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MqttService {
+    private final MqttClient mqttClient;
+    private final SensorService sensorService;
+
+    /**
+     * - 디바이스의 shadow 메타데이터 변경사항(등록/수정)을 구독
+     * @throws MqttException mqtt 연결에 실패시 MqttException 발생
+     */
+    @PostConstruct
+    public void SensorShadowSubscription() throws MqttException {
+        // 🟢 구독할 Thing 설정
+        String thingName = "Sensor";
+        // #는 topic의 여러 level을 대체 가능, +는 topic의 단일 level을 대체 가능
+        String topic = "$aws/things/" + thingName + "/shadow/name/+/update/documents";
+        mqttClient.subscribe(topic,1,  (t, msg) -> {
+            String payload = new String(msg.getPayload(), StandardCharsets.UTF_8);
+
+            // JSON 파싱 및 DB 저장은 이후 구현 예정
+            try{
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode jsonNode = mapper.readTree(payload);
+                log.info("📥 MQTT 수신 (topic: {}): {}", t, jsonNode);
+                String sensorId = jsonNode.at("/id").asText();
+                String type = jsonNode.at("/type").asText();
+                SensorDto dto = new SensorDto(sensorId, type);
+                sensorService.saveSensor(dto); // 중복이면 예외 발생
+                log.info("✅ 센서 저장 완료: {}", sensorId);
+            } catch (DataIntegrityViolationException e) {
+                log.warn("⚠️ 중복 센서 저장 시도 차단됨: {}", e.getMessage());
+            } catch (Exception e) {
+                log.error("❌ JSON 파싱 또는 저장 중 오류: {}", e.getMessage());
+            }
+
+        });
+        log.info("📡 MQTT subscribe 완료됨: topic = {}", topic); // ★ subscribe 후에도 로그
+    }
+}

--- a/src/main/java/com/factoreal/backend/Util/SslUtil.java
+++ b/src/main/java/com/factoreal/backend/Util/SslUtil.java
@@ -1,13 +1,27 @@
 package com.factoreal.backend.Util;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 
 import javax.net.ssl.*;
-import java.io.*;
-import java.security.*;
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyStore;
+import java.security.Security;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -18,7 +32,49 @@ import java.util.stream.Stream;
  * 🔐 AWS IoT MQTT 통신을 위한 SSLContext 생성 유틸리티 클래스
  * - 인증서 (device cert, private key, CA cert)를 이용하여 SSL 소켓을 생성함
  */
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class SslUtil {
+    private final SecretsManagerClient awsSecretsManagerClient;
+
+    /**
+     * @param secretName       AWS SecretManager에서 사용한 secret 식별자
+     * 🔐 PEM 텍스트 기반 SSLSocketFactory 생성 (Secrets Manager 등에서 가져온 경우)
+     */
+    public SSLSocketFactory getSocketFactoryFromSecrets(String secretName) throws Exception {
+        // Step 1. SecretsManager에서 가져오기
+        GetSecretValueRequest request = GetSecretValueRequest.builder()
+                .secretId(secretName)
+                .build();
+
+        GetSecretValueResponse response = awsSecretsManagerClient.getSecretValue(request);
+
+        if (response.secretString() == null) {
+            throw new IllegalStateException("Secret is binary or null.");
+        }
+
+        // String의 경우 불변타입이여서 메모리에 남아 있음 -> Byte로 받아와서 비울 수 있도록
+        byte[] secretBytes = response.secretString().getBytes(StandardCharsets.UTF_8);
+        try {
+            JsonNode json = new ObjectMapper().readTree(secretBytes);
+            String deviceCert = json.get("certificate").asText();
+            String privateKey = json.get("privateKey").asText();
+            String rootCA = json.get("rootCA").asText();
+
+            InputStream certStream = new ByteArrayInputStream(deviceCert.getBytes(StandardCharsets.UTF_8));
+            InputStream keyStream = new ByteArrayInputStream(privateKey.getBytes(StandardCharsets.UTF_8));
+            InputStream caStream = new ByteArrayInputStream(rootCA.getBytes(StandardCharsets.UTF_8));
+
+            return createSocketFactory(caStream, certStream, keyStream);
+        }catch (Exception e){
+            log.info("❌Pem키 파싱 중 오류 발생");
+            throw e;
+        }finally {
+            // 메모리에서 Secret Manager 정보 제거
+            Arrays.fill(secretBytes, (byte) 0);
+        }
+    }
 
     /**
      * 📦 MQTT 연결용 SSLSocketFactory 생성 메서드
@@ -28,18 +84,27 @@ public class SslUtil {
      * @return SSLSocketFactory 객체
      * @throws Exception 모든 예외 전달 (파일, 키, 인증서 파싱 오류 등)
      */
-    public static SSLSocketFactory getSocketFactory(String caCrtFile, String crtFile, String keyFile) throws Exception {
+    public SSLSocketFactory getSocketFactoryFromFiles(String caCrtFile, String crtFile, String keyFile) throws Exception {
+        try (
+                FileInputStream caFis = new FileInputStream(caCrtFile);
+                FileInputStream crtFis = new FileInputStream(crtFile);
+                FileInputStream keyReader = new FileInputStream(keyFile)
+        ) {
+            return createSocketFactory(caFis, crtFis, keyReader);
+        }
+    }
 
+    private static SSLSocketFactory createSocketFactory(InputStream caFile, InputStream certInput, InputStream keyInput) throws Exception {
         // BouncyCastle Provider 등록 (PEM 파싱용)
         Security.addProvider(new BouncyCastleProvider());
 
         // CA 인증서와 디바이스 인증서
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
-        X509Certificate caCert = (X509Certificate) cf.generateCertificate(new FileInputStream(caCrtFile));
-        X509Certificate cert = (X509Certificate) cf.generateCertificate(new FileInputStream(crtFile));
+        X509Certificate caCert = (X509Certificate) cf.generateCertificate(caFile);
+        X509Certificate cert = (X509Certificate) cf.generateCertificate(certInput);
 
         // 디바이스 개인키 PEM → Keypair 변환
-        PEMParser pemParser = new PEMParser(new FileReader(keyFile));
+        PEMParser pemParser = new PEMParser(new InputStreamReader(keyInput,StandardCharsets.UTF_8));
         Object object = pemParser.readObject();
         JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
         KeyPair key = converter.getKeyPair((PEMKeyPair) object);

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,4 @@
+# ===============================
+# .env File Only Use in Dev. When Deploy use Environment Variable
+# ===============================
+spring.config.import=optional:file:.env[.properties]

--- a/src/main/resources/application-iam.properties
+++ b/src/main/resources/application-iam.properties
@@ -1,3 +1,0 @@
-aws.access-key=IAM access Key
-aws.secret-key=IAM Secret Key
-aws.region=ap-northeast-2

--- a/src/main/resources/application-iam.properties
+++ b/src/main/resources/application-iam.properties
@@ -1,0 +1,3 @@
+aws.access-key=IAM access Key
+aws.secret-key=IAM Secret Key
+aws.region=ap-northeast-2

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=backend
-
+spring.profiles.include=iam
 # ===============================
 # H2 Database Configuration -- TEMP DB
 # ===============================

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=backend
-spring.profiles.include=iam
+spring.profiles.include=dev
 # ===============================
 # H2 Database Configuration -- TEMP DB
 # ===============================
@@ -45,4 +45,9 @@ logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 ## Swagger URL ?? ??
 springdoc.swagger-ui.path=/docs
 
-
+# [NOTICE] AWS IAM credentials are loaded from external environment variables.
+# Be sure to set the values in a .env file or as environment variables in the operating environment.
+# Never write the actual key values directly in this file (security risk and risk of Git exposure).
+aws.access-key=${AWS_IAM_ACCESS_KEY}
+aws.secret-key=${AWS_IAM_SECRET_KEY}
+aws.region=ap-northeast-2


### PR DESCRIPTION
## 📌 PR 제목
[fix] pem파일 Secret Manager에서 가져오도록 방법 추가(기존 file 방법도 유지)

---

## ✨ 변경 사항
- Pem 읽는 방식 추가(기존 : File, 변경후 : File or SecretManager)
- aws IAM 관리를 위한 AwsServiceConfig 추가
- mqtt 커넥션 객체 빈으로 등록
- mqttService에서 Subscribe, Publish(pub-sub)관리하도록 책임 분리
- IAM access/secret key 사용하는 .env파일 추가 (dev환경에서 사용)

---

## 💬 추가 설명
- .env파일설정방법은 컨플루언스에 기재
https://facto-real.atlassian.net/wiki/pages/resumedraft.action?draftId=12550149&draftShareId=37d0571d-c1ef-4328-8c44-2a66ffcc47bc